### PR TITLE
Getting started: Update log output for Nutils v9

### DIFF
--- a/src/start.md
+++ b/src/start.md
@@ -61,12 +61,16 @@ python poisson.py
 This should produce the following output:
 
 ```
-nutils v7.0
-optimize > constrained 40/121 dofs
-optimize > optimum value 0.00e+00
-optimize > solve > solving 81 dof system to machine precision using arnoldi solver
-optimize > solve > solver returned with residual 6e-17
-optimize > optimum value -1.75e-02
+NUTILS 9.0 "Jook-Sing"
+arguments > nelems=10
+arguments > etype=square
+solve_constraints > optimizing for argument udofs (121) with drop tolerance 1e-12
+solve_constraints > residual norm: 0.0e+00
+solve_constraints > optimal value: 0.0e+00
+solve_constraints > constrained 40 degrees of freedom of udofs
+solve > optimizing for argument udofs (121) using direct method
+solve > residual norm: 6.5e-17
+solve > optimal value: -1.7e-02
 u.png
 log written to file:///home/myusername/public_html/poisson.py/log.html
 ```

--- a/src/start.md
+++ b/src/start.md
@@ -39,7 +39,7 @@ def main(nelems: int = 10, etype: str = 'square'):
     udofs = solver.optimize('udofs',
         domain.integral((g @ g / 2 - u) * J, degree=1), constrain=cons)
     bezier = domain.sample('bezier', 3)
-    x, u = bezier.eval([x, u], udofs=udofs)
+    x, u = bezier.eval([x, u], arguments=dict(udofs=udofs))
     export.triplot('u.png', x, u, tri=bezier.tri, hull=bezier.hull)
 
 cli.run(main)


### PR DESCRIPTION
In the [Getting started](https://nutils.org/start.html) page, the current output suggests Nutils v7, but the code only runs with Nutils v9 (or at least not with v7 or v8).

Additionally, I am getting a deprecation warning for `x, u = bezier.eval([x, u], udofs=udofs)`:

```
NutilsDeprecationWarning: providing evaluation arguments as keyword arguments is deprecated, please use the "arguments" parameter instead
```

This PR updates the output, without the deprecation warning. The [respective script from the examples](https://github.com/evalf/nutils/blob/d73749ff7d64c9ccafdbb88cd442f80b9448c118/examples/poisson.py) is a bit different, and I am not sure if this is by design or just happened:

https://github.com/evalf/nutils/blob/d73749ff7d64c9ccafdbb88cd442f80b9448c118/examples/poisson.py#L22-L31