### PR TITLE
Getting started: Use a venv instead of user-wide installation

### DIFF
--- a/src/start.md
+++ b/src/start.md
@@ -10,10 +10,11 @@ syntax, and explore the [examples](examples.md) for inspiration.
 
 With Python version 3.7 or newer installed, Nutils and Matplotlib can be
 installed via the [Python Package Index](https://pypi.org/project/nutils/)
-using the pip package installer. In a terminal window:
+using the pip package installer.
+In a terminal window with an active [Python virtual environment](https://docs.python.org/3/library/venv.html):
 
 ```sh
-python -m pip install --user nutils matplotlib
+python -m pip install nutils matplotlib
 ```
 
 Note that Nutils depends on Numpy, Treelog and Stringly, which means that these


### PR DESCRIPTION
The `pip install --user` is forbidden by default in some systems, such as on Ubuntu 24.04.
Looking at the documentation, the only place where this is mentioned is in the [Getting Started page](https://nutils.org/start.html).

This PR changes the text to guide into using a venv instead.